### PR TITLE
Fix signature of ScheduleTimer() to allow variadic arguments.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3,8 +3,16 @@ import { Constructor, Library } from "@wowts/tslib";
 export type Callback = (timer: Timer) => void;
 
 export interface AceTimer {
-    ScheduleTimer(method: string |  Callback, interval: number): Timer;
-    ScheduleRepeatingTimer(method: string |  Callback, interval: number): Timer;
+    ScheduleTimer(
+        method: string | Callback,
+        interval: number,
+        ...parameters: any[]
+    ): Timer;
+    ScheduleRepeatingTimer(
+        method: string | Callback,
+        interval: number,
+        ...parameters: any[]
+    ): Timer;
     CancelTimer(handle: Timer): void;
 }
 
@@ -17,8 +25,20 @@ export interface Timer {
 const lib: Library<AceTimer> = {
     Embed<T extends Constructor<{}>>(Base: T): Constructor<AceTimer> & T {
         return class extends Base {
-            public ScheduleTimer(method: string |  Callback, interval: number): Timer { return { delay: interval, looping: false, ends: interval }; }
-            public ScheduleRepeatingTimer(method: string |  Callback, interval: number): Timer { return { delay: interval, looping: true, ends: interval }; }
+            public ScheduleTimer(
+                method: string | Callback,
+                interval: number,
+                ...parameters: any[]
+            ): Timer {
+                return { delay: interval, looping: false, ends: interval };
+            }
+            public ScheduleRepeatingTimer(
+                method: string | Callback,
+                interval: number,
+                ...parameters: any[]
+            ): Timer {
+                return { delay: interval, looping: true, ends: interval };
+            }
             public CancelTimer(handle: Timer): void {}
         };
     },


### PR DESCRIPTION
AceTimer:ScheduleTimer(func, delay, ...) allows for an unlimited
number of arguments after the delay paramter.  Fix the function
signatures for ScheduleTimer() and ScheduleRepeatingTimer() to
accept a variable number of parameters after the two required ones.

This fixes issue #1.